### PR TITLE
Clarify expectation on websockets dependency

### DIFF
--- a/charter.html
+++ b/charter.html
@@ -221,7 +221,7 @@
           <h3 id="w3c-coordination">W3C Groups</h3>
           <dl>
             <dt><a href="https://www.w3.org/2019/html/">HTML Working Group</a></dt>
-            <dd>The HTML Working Group <span class=todo>publishes the W3C Recommendation of the WebSockets API</span> which is expected to provide one fallback approach for the WebTransport API when a WebTransport connection cannot be established.</dd>
+            <dd>The HTML Working Group <span class=todo>publishes the W3C Recommendation of the WebSockets API</span> which may play a role in fallback scenarios when a WebTransport connection cannot be established.</dd>
             <dt><a href="https://www.w3.org/2011/04/webrtc/">Web Real-Time Communications Working Group</a></dt>
             <dd>The WebRTC API developed by the WebRTC Working Group enables data transfer between peers with similar charactestics to the ones enabled by WebTransport, and may consider adopting the WebTransport API for peer-to-peer data transfer.</dd>
             <dt><a href="https://www.w3.org/2011/webtv/">Media and Entertainment Interest Group</a></dt>


### PR DESCRIPTION
It's not clear that WebSockets will be a preset fallback scenario, so the charter should not claim it is

(based on discussions with @aboba)